### PR TITLE
Add Event Throttling for OnMouseEnter

### DIFF
--- a/Example/src/Pages/MultiListDemo.fs
+++ b/Example/src/Pages/MultiListDemo.fs
@@ -63,6 +63,7 @@ module MultiListDemo =
         Opacity 0.2
         PointerEvents "None"
       ]
+      MoveThrottleTimeMs = Some (System.TimeSpan.FromMilliseconds 500.)
   }
 
   let createDraggable model elementId dispatch =
@@ -112,5 +113,5 @@ module MultiListDemo =
     | Init ->
       model, Cmd.none
     | DndMsg msg ->
-      let dndModel = dragAndDropUpdate msg model.DragAndDrop
-      { model with DragAndDrop = dndModel }, Cmd.none
+      let dndModel, cmd = dragAndDropUpdate msg model.DragAndDrop
+      { model with DragAndDrop = dndModel }, Cmd.map DndMsg cmd

--- a/Example/src/Pages/SingleListDemo.fs
+++ b/Example/src/Pages/SingleListDemo.fs
@@ -119,5 +119,5 @@ module SingleListDemo =
       let dndModel = DragAndDropModel.createWithItems ids
       { model with DragAndDrop = dndModel }, Cmd.none
     | DndMsg msg ->
-      let dndModel = dragAndDropUpdate msg model.DragAndDrop
-      { model with DragAndDrop = dndModel }, Cmd.none
+      let dndModel, cmd = dragAndDropUpdate msg model.DragAndDrop
+      { model with DragAndDrop = dndModel }, Cmd.map DndMsg cmd

--- a/Example/src/Pages/TableDemo.fs
+++ b/Example/src/Pages/TableDemo.fs
@@ -214,8 +214,8 @@ module TableDemo =
     | InitWithSampleData ->
       (initWithSampleData()), Cmd.none
     | DndMsg msg ->
-      let dndModel = dragAndDropUpdate msg model.DragAndDrop
-      { model with DragAndDrop = dndModel }, Cmd.none
+      let dndModel, cmd = dragAndDropUpdate msg model.DragAndDrop
+      { model with DragAndDrop = dndModel }, Cmd.map DndMsg cmd
     | AddRow ->
       let row = ContentValue.Empty()
       let model = addContent model row

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,7 @@
 source https://www.nuget.org/api/v2
 source https://api.nuget.org/v3/index.json
 storage: none
-nuget FSharp.Core 5.0
+nuget FSharp.Core 5.0.1
 nuget Microsoft.SourceLink.GitHub 1.0.0 copy_local: true
 nuget Expecto 9.0.2
 nuget YoloDev.Expecto.TestSdk 0.9.2
@@ -14,6 +14,7 @@ nuget Fable.Browser.Dom
 nuget Fable.Elmish
 nuget Fable.Elmish.React
 nuget Fable.React
+nuget Fable.Elmish.Throttle 0.1.0
 
 // [ FAKE GROUP ]
 group Build

--- a/paket.lock
+++ b/paket.lock
@@ -35,11 +35,20 @@ NUGET
       Fable.Elmish (>= 3.0) - restriction: >= netstandard2.0
       Fable.React (>= 5.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+    Fable.Elmish.Throttle (0.1)
+      Fable.Browser.Dom (>= 2.4) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.2.7) - restriction: >= netstandard2.0
+      Fable.Elmish (>= 3.1) - restriction: >= netstandard2.0
+      Fable.Promise (>= 2.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 5.0.1) - restriction: >= netstandard2.0
+    Fable.Promise (2.2) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
+      FSharp.Core (>= 5.0) - restriction: >= netstandard2.0
     Fable.React (7.4)
       Fable.Browser.Dom (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
-    FSharp.Core (5.0)
+    FSharp.Core (5.0.1)
     Microsoft.Build.Tasks.Git (1.0) - copy_local: true
     Microsoft.CodeCoverage (16.8) - restriction: || (>= net45) (>= netcoreapp2.1)
     Microsoft.CSharp (4.7) - restriction: || (&& (< netstandard1.3) (>= uap10.0)) (&& (< netstandard2.0) (>= uap10.0))

--- a/src/Elmish.DragAndDrop/paket.references
+++ b/src/Elmish.DragAndDrop/paket.references
@@ -5,3 +5,4 @@ Fable.Browser.Event
 Fable.Browser.Dom
 Fable.Elmish
 Fable.React
+Fable.Elmish.Throttle


### PR DESCRIPTION
In some test scenarios, an item would flicker back & forth between 2 spots rapidly. This doesn't entirely solve that issue but it does mitigate it, by letting the user configure a throttle timer for elements moving. 